### PR TITLE
Wait for pressure to be regulated instead of fixed delay

### DIFF
--- a/examples/python/src/driver/drvPgva.py
+++ b/examples/python/src/driver/drvPgva.py
@@ -97,13 +97,25 @@ class PGVA:
         data = 0
         try:
             data = self.client.read_input_registers(register, 1, unit=self.pgvaConfig['modbusSlave'])
-            return data.registers[0]
         except Exception as e:
             print("Error while reading : ", str(e))
+
+        result = data.registers[0]
+
+        if (sign):
+            if (result & 0x8000):
+                result = -(~result & 0xFFFF) - 1
+
+        return result
+
 
 
     def writeData(self, register, val, sign=True):
         status = object
+
+        if (sign):
+            val &= 0xFFFF
+
         print(f"{register}, {val}")
         try:
             if val < 0:


### PR DESCRIPTION
## **Description**

Up to now the driver as waiting a fixed period of 0.5 seconds after setting the pressure to regulate and before opening the output valve. Sometimes, however, more time may be needed for the device to regulate the requested pressure. Because of that a function is added that polls the current pressure.

Fixes #28 

## **Type of change**

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

## **How Has This Been Tested?**

Integration tests performed and passed OK. 

Test Configuration:

* Firmware version: 0.0.1
* Hardware: PGVA
* Toolchain: Python 3.8
* SDK: -
